### PR TITLE
Specify static version preference

### DIFF
--- a/lanretam/settings_shared.py
+++ b/lanretam/settings_shared.py
@@ -56,3 +56,5 @@ SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 WIND_AFFIL_HANDLERS = ['lanretam.main.auth.WagtailEditorMapper',
                        'djangowind.auth.StaffMapper',
                        'djangowind.auth.SuperuserMapper']
+
+WAGTAILADMIN_STATIC_FILE_VERSION_STRINGS = True


### PR DESCRIPTION
This chunk of code has some expectations that the settings.STATICFILES_STORAGE is set...but during migrations that is not always the case. Setting the value to True to work around this issue.
https://github.com/wagtail/wagtail/blob/master/wagtail/admin/staticfiles.py